### PR TITLE
Context Menu for snapping view to primary axis planes in 3D plots

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -646,6 +646,14 @@ class FigureManagerTk(FigureManagerBase):
         is_fullscreen = bool(self.window.attributes('-fullscreen'))
         self.window.attributes('-fullscreen', not is_fullscreen)
 
+    def context_menu(self, event, labels=None, actions=None):
+        if labels is None or actions is None:
+            return
+        menu = tk.Menu(self.window, tearoff=0)
+        for label, action in zip(labels, actions):
+            menu.add_command(label=label, command=action)
+        menu.tk_popup(event.guiEvent.x_root, event.guiEvent.y_root)
+
 
 class NavigationToolbar2Tk(NavigationToolbar2, tk.Frame):
     def __init__(self, canvas, window=None, *, pack_toolbar=True):

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -647,7 +647,7 @@ class FigureManagerTk(FigureManagerBase):
         self.window.attributes('-fullscreen', not is_fullscreen)
 
     def context_menu(self, event, labels=None, actions=None):
-        if labels is None or actions is None:
+        if not labels or not actions:
             return
         menu = tk.Menu(self.window, tearoff=0)
         for label, action in zip(labels, actions):

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -591,6 +591,17 @@ class FigureManagerGTK3(_FigureManagerGTK):
     _toolbar2_class = NavigationToolbar2GTK3
     _toolmanager_toolbar_class = ToolbarGTK3
 
+    def context_menu(self, event, labels=None, actions=None):
+        if labels is None or actions is None:
+            return
+        menu = Gtk.Menu()
+        for label, action in zip(labels, actions):
+            item = Gtk.MenuItem(label=label)
+            menu.append(item)
+            item.connect('activate', lambda _, a=action: a())
+            item.show()
+        menu.popup_at_pointer(event.guiEvent)
+
 
 @_BackendGTK.export
 class _BackendGTK3(_BackendGTK):

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -600,6 +600,7 @@ class FigureManagerGTK3(_FigureManagerGTK):
             menu.append(item)
             item.connect('activate', lambda _, a=action: a())
             item.show()
+        menu.connect('selection-done', lambda m: m.destroy())
         menu.popup_at_pointer(event.guiEvent)
 
 

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -592,7 +592,7 @@ class FigureManagerGTK3(_FigureManagerGTK):
     _toolmanager_toolbar_class = ToolbarGTK3
 
     def context_menu(self, event, labels=None, actions=None):
-        if labels is None or actions is None:
+        if not labels or not actions:
             return
         menu = Gtk.Menu()
         for label, action in zip(labels, actions):

--- a/lib/matplotlib/backends/backend_gtk4.py
+++ b/lib/matplotlib/backends/backend_gtk4.py
@@ -642,17 +642,19 @@ class FigureManagerGTK4(_FigureManagerGTK):
             return
         menu = Gio.Menu()
         action_group = Gio.SimpleActionGroup()
-        for i, (label, action) in enumerate(zip(labels, actions)):
-            action_name = f"{label}"
+        for label, action in zip(labels, actions):
+            action_name = label.replace(" ", "_")
             g_action = Gio.SimpleAction.new(action_name, None)
             g_action.connect("activate", lambda *_, a=action: a())
             action_group.add_action(g_action)
             menu.append(label, f"win.{action_name}")
+
         self.canvas.insert_action_group("win", action_group)
         popover = Gtk.PopoverMenu.new_from_model(menu)
         popover.set_parent(self.canvas)
         popover.set_has_arrow(False)
         popover.set_halign(Gtk.Align.START)
+
         scale = self.canvas.get_scale_factor()
         height = self.canvas.get_height()
         rect = Gdk.Rectangle()

--- a/lib/matplotlib/backends/backend_gtk4.py
+++ b/lib/matplotlib/backends/backend_gtk4.py
@@ -637,6 +637,32 @@ class FigureManagerGTK4(_FigureManagerGTK):
     _toolbar2_class = NavigationToolbar2GTK4
     _toolmanager_toolbar_class = ToolbarGTK4
 
+    def context_menu(self, event, labels=None, actions=None):
+        if not labels or not actions:
+            return
+        menu = Gio.Menu()
+        action_group = Gio.SimpleActionGroup()
+        for i, (label, action) in enumerate(zip(labels, actions)):
+            action_name = f"{label}"
+            g_action = Gio.SimpleAction.new(action_name, None)
+            g_action.connect("activate", lambda *_, a=action: a())
+            action_group.add_action(g_action)
+            menu.append(label, f"win.{action_name}")
+        self.canvas.insert_action_group("win", action_group)
+        popover = Gtk.PopoverMenu.new_from_model(menu)
+        popover.set_parent(self.canvas)
+        popover.set_has_arrow(False)
+        popover.set_halign(Gtk.Align.START)
+        scale = self.canvas.get_scale_factor()
+        height = self.canvas.get_height()
+        rect = Gdk.Rectangle()
+        rect.x = int(event.x / scale)
+        rect.y = int(height - (event.y / scale))
+        rect.width = 1
+        rect.height = 1
+        popover.set_pointing_to(rect)
+        popover.popup()
+
 
 @_BackendGTK.export
 class _BackendGTK4(_BackendGTK):

--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -8,6 +8,8 @@ from .backend_agg import FigureCanvasAgg
 from matplotlib.backend_bases import (
     _Backend, FigureCanvasBase, FigureManagerBase, NavigationToolbar2,
     ResizeEvent, TimerBase, _allow_interrupt)
+from Foundation import NSObject
+import AppKit
 
 
 class TimerMac(_macosx.Timer, TimerBase):
@@ -145,6 +147,12 @@ class NavigationToolbar2Mac(_macosx.NavigationToolbar2, NavigationToolbar2):
         return filename
 
 
+class MenuCallback(NSObject):
+    def action_(self, sender):
+        if hasattr(self, 'callback'):
+            self.callback()
+
+
 class FigureManagerMac(_macosx.FigureManager, FigureManagerBase):
     _toolbar2_class = NavigationToolbar2Mac
 
@@ -160,6 +168,23 @@ class FigureManagerMac(_macosx.FigureManager, FigureManagerBase):
         if mpl.is_interactive():
             self.show()
             self.canvas.draw_idle()
+
+    def context_menu(self, event, labels=None, actions=None):
+        if labels is None or actions is None:
+            return
+        menu = AppKit.NSMenu.alloc().init()
+        self._menu_callbacks = []
+        for label, action in zip(labels, actions):
+            target = MenuCallback.alloc().init()
+            target.callback = action
+            self._menu_callbacks.append(target)
+            item = AppKit.NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
+                label, "action:", ""
+            )
+            item.setTarget_(target)
+            menu.addItem_(item)
+        mouse_loc = AppKit.NSEvent.mouseLocation()
+        menu.popUpMenuPositioningItem_atLocation_inView_(None, mouse_loc, None)
 
     def _close_button_pressed(self):
         Gcf.destroy(self)

--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -8,8 +8,6 @@ from .backend_agg import FigureCanvasAgg
 from matplotlib.backend_bases import (
     _Backend, FigureCanvasBase, FigureManagerBase, NavigationToolbar2,
     ResizeEvent, TimerBase, _allow_interrupt)
-from Foundation import NSObject
-import AppKit
 
 
 class TimerMac(_macosx.Timer, TimerBase):
@@ -147,12 +145,6 @@ class NavigationToolbar2Mac(_macosx.NavigationToolbar2, NavigationToolbar2):
         return filename
 
 
-class MenuCallback(NSObject):
-    def action_(self, sender):
-        if hasattr(self, 'callback'):
-            self.callback()
-
-
 class FigureManagerMac(_macosx.FigureManager, FigureManagerBase):
     _toolbar2_class = NavigationToolbar2Mac
 
@@ -168,23 +160,6 @@ class FigureManagerMac(_macosx.FigureManager, FigureManagerBase):
         if mpl.is_interactive():
             self.show()
             self.canvas.draw_idle()
-
-    def context_menu(self, event, labels=None, actions=None):
-        if labels is None or actions is None:
-            return
-        menu = AppKit.NSMenu.alloc().init()
-        self._menu_callbacks = []
-        for label, action in zip(labels, actions):
-            target = MenuCallback.alloc().init()
-            target.callback = action
-            self._menu_callbacks.append(target)
-            item = AppKit.NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
-                label, "action:", ""
-            )
-            item.setTarget_(target)
-            menu.addItem_(item)
-        mouse_loc = AppKit.NSEvent.mouseLocation()
-        menu.popUpMenuPositioningItem_atLocation_inView_(None, mouse_loc, None)
 
     def _close_button_pressed(self):
         Gcf.destroy(self)

--- a/lib/matplotlib/backends/backend_qt.py
+++ b/lib/matplotlib/backends/backend_qt.py
@@ -627,6 +627,17 @@ class FigureManagerQT(FigureManagerBase):
         else:
             self.window.showFullScreen()
 
+    def context_menu(self, event, labels=None, actions=None):
+        if labels is None or actions is None:
+            return
+        menu = QtWidgets.QMenu(self.window)
+        for label, action in zip(labels, actions):
+            menu.addAction(label).triggered.connect(action)
+        if hasattr(event.guiEvent, 'globalPosition'):
+            menu.exec(event.guiEvent.globalPosition().toPoint())
+        else:
+            menu.exec(event.guiEvent.globalPos())
+
     def _widgetclosed(self):
         CloseEvent("close_event", self.canvas)._process()
         if self.window._destroying:

--- a/lib/matplotlib/backends/backend_qt.py
+++ b/lib/matplotlib/backends/backend_qt.py
@@ -633,7 +633,10 @@ class FigureManagerQT(FigureManagerBase):
         menu = QtWidgets.QMenu(self.window)
         for label, action in zip(labels, actions):
             menu.addAction(label).triggered.connect(action)
-        menu.exec(event.guiEvent.globalPos())
+        if hasattr(event.guiEvent, 'globalPosition'):
+            menu.exec(event.guiEvent.globalPosition().toPoint())
+        else:
+            menu.exec(event.guiEvent.globalPos())
 
     def _widgetclosed(self):
         CloseEvent("close_event", self.canvas)._process()

--- a/lib/matplotlib/backends/backend_qt.py
+++ b/lib/matplotlib/backends/backend_qt.py
@@ -628,15 +628,12 @@ class FigureManagerQT(FigureManagerBase):
             self.window.showFullScreen()
 
     def context_menu(self, event, labels=None, actions=None):
-        if labels is None or actions is None:
+        if not labels or not actions:
             return
         menu = QtWidgets.QMenu(self.window)
         for label, action in zip(labels, actions):
             menu.addAction(label).triggered.connect(action)
-        if hasattr(event.guiEvent, 'globalPosition'):
-            menu.exec(event.guiEvent.globalPosition().toPoint())
-        else:
-            menu.exec(event.guiEvent.globalPos())
+        menu.exec(event.guiEvent.globalPos())
 
     def _widgetclosed(self):
         CloseEvent("close_event", self.canvas)._process()

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1019,7 +1019,7 @@ class FigureManagerWx(FigureManagerBase):
         self.frame.ShowFullScreen(not self.frame.IsFullScreen())
 
     def context_menu(self, event, labels=None, actions=None):
-        if labels is None or actions is None:
+        if not labels or not actions:
             return
         menu = wx.Menu()
         for label, action in zip(labels, actions):

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1018,6 +1018,16 @@ class FigureManagerWx(FigureManagerBase):
         # docstring inherited
         self.frame.ShowFullScreen(not self.frame.IsFullScreen())
 
+    def context_menu(self, event, labels=None, actions=None):
+        if labels is None or actions is None:
+            return
+        menu = wx.Menu()
+        for label, action in zip(labels, actions):
+            item = menu.Append(wx.NewIdRef(), label)
+            menu.Bind(wx.EVT_MENU, lambda _, a=action: a(), item)
+        self.canvas.PopupMenu(menu, event.guiEvent.GetPosition())
+        menu.Destroy()
+
     def get_window_title(self):
         # docstring inherited
         return self.window.GetTitle()

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1380,13 +1380,14 @@ class Axes3D(Axes):
                 self.view_init(elev=elev, azim=azim)
                 canvas.draw_idle()
 
-            canvas.manager.context_menu(
-                event,
-                labels=["Go to X-Y view", "Go to Y-Z view", "Go to X-Z view"],
-                actions=[functools.partial(draw_lambda, elev=90, azim=-90),
-                         functools.partial(draw_lambda, elev=0, azim=0),
-                         functools.partial(draw_lambda, elev=0, azim=-90)],
-            )
+            if hasattr(canvas.manager, "context_menu"):
+                canvas.manager.context_menu(
+                    event,
+                    labels=["Go to X-Y view", "Go to Y-Z view", "Go to X-Z view"],
+                    actions=[functools.partial(draw_lambda, elev=90, azim=-90),
+                            functools.partial(draw_lambda, elev=0, azim=0),
+                            functools.partial(draw_lambda, elev=0, azim=-90)],
+                )
 
         toolbar = self.get_figure(root=True).canvas.toolbar
         # backend_bases.release_zoom and backend_bases.release_pan call

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -16,6 +16,7 @@ import math
 import textwrap
 import warnings
 
+import functools
 import numpy as np
 
 import matplotlib as mpl
@@ -186,6 +187,8 @@ class Axes3D(Axes):
         # Calculate the pseudo-data width and height
         pseudo_bbox = self.transLimits.inverted().transform([(0, 0), (1, 1)])
         self._pseudo_w, self._pseudo_h = pseudo_bbox[1] - pseudo_bbox[0]
+
+        self._mouse_moved = False
 
         # mplot3d currently manages its own spines and needs these turned off
         # for bounding box calculations
@@ -1357,6 +1360,7 @@ class Axes3D(Axes):
 
     def _button_press(self, event):
         if event.inaxes == self:
+            self._mouse_moved = False
             self.button_pressed = event.button
             self._sx, self._sy = event.xdata, event.ydata
             toolbar = self.get_figure(root=True).canvas.toolbar
@@ -1367,6 +1371,23 @@ class Axes3D(Axes):
 
     def _button_release(self, event):
         self.button_pressed = None
+
+        if event.button in self._zoom_btn and event.inaxes == self \
+            and not self._mouse_moved:
+            canvas = self.get_figure(root=True).canvas
+
+            def draw_lambda(elev, azim):
+                self.view_init(elev=elev, azim=azim)
+                canvas.draw_idle()
+
+            canvas.manager.context_menu(
+                event,
+                labels=["Go to X-Y view", "Go to Y-Z view", "Go to X-Z view"],
+                actions=[functools.partial(draw_lambda, elev=90, azim=-90),
+                         functools.partial(draw_lambda, elev=0, azim=0),
+                         functools.partial(draw_lambda, elev=0, azim=-90)],
+            )
+
         toolbar = self.get_figure(root=True).canvas.toolbar
         # backend_bases.release_zoom and backend_bases.release_pan call
         # push_current, so check the navigation mode so we don't call it twice
@@ -1546,11 +1567,6 @@ class Axes3D(Axes):
         if not self.button_pressed:
             return
 
-        if self.get_navigate_mode() is not None:
-            # we don't want to rotate if we are zooming/panning
-            # from the toolbar
-            return
-
         if self.M is None:
             return
 
@@ -1562,6 +1578,14 @@ class Axes3D(Axes):
         dx, dy = x - self._sx, y - self._sy
         w = self._pseudo_w
         h = self._pseudo_h
+
+        if (dx**2 + dy**2) > 1e-6:
+            self._mouse_moved = True
+
+        if self.get_navigate_mode() is not None:
+            # we don't want to rotate if we are zooming/panning
+            # from the toolbar
+            return
 
         # Rotation
         if self.button_pressed in self._rotate_btn:


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->

closes 23544
This PR introduces a feature that adds context menu on 3d Axes triggered by right-click of the mouse.

1. Added `context_menu()` in Figure Manager that takes arguments, a list of labels and a list of corresponding functions to execute upon selection.

2. Modified `_button_release()` to call `canvas.manager.context_menu()` with functions for setting orthographic views when the right-click is **released** on the mouse without moving it significantly. Mouse movement is handled in `_on_move()` using a small threshold because previously I observed trackpad (on macOS) reported micro-movements during a static click, which falsely flagged the action as _"drag"_ and blocked the menu in specific backends.

### **Backends**

- [x] TkAgg: `tk.Menu` implementation.
- [x] QtAgg: `QtWidgets.QMenu` implementation.
- [x] WxAgg: Uses `wx.Menu` and `PopupMenu`.
- [x] Gtk3Agg: Uses `Gtk.Menu`.
- [x] Gtk4Agg: Uses `Gtk.PopoverMenu` and `Gio.Menu`.
- [x] MacOSX: Uses `AppKit` (PyObjC) to display a native NSMenu, utilizing a target/action dispatcher.
- [ ] WebAgg: Yet to be implemented
- [ ] NbAgg: Yet to be implemented

```python
import matplotlib

# matplotlib.use("TkAgg") # Change to QtAgg, GTK4Agg, MacOSX, WxAgg, etc.
import matplotlib.pyplot as plt

fig = plt.figure()
ax = fig.add_subplot(projection="3d")
ax.plot([0, 1, 2], [0, 1, 0], [0, 1, 0])

plt.show()
```

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
