### PR TITLE
Hamburger Menu

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2903,6 +2903,7 @@ class NavigationToolbar2:
         ('Home', 'Reset original view', 'home', 'home'),
         ('Back', 'Back to previous view', 'back', 'back'),
         ('Forward', 'Forward to next view', 'forward', 'forward'),
+        ('Views', 'Snap into planar views', 'matplotlib', 'snap_view'),
         (None, None, None, None),
         ('Pan',
          'Left button pans, Right button zooms\n'
@@ -2934,6 +2935,16 @@ class NavigationToolbar2:
 
         self.mode = _Mode.NONE  # a mode string for the status bar
         self.set_history_buttons()
+
+        def draw_lambda(elev, azim):
+            ax = self.canvas.figure.gca()
+            ax.view_init(elev=elev, azim=azim)
+            self.canvas.draw_idle()
+        self.options = [
+            ("Go to X-Y view", functools.partial(draw_lambda, elev=90, azim=-90)),
+            ("Go to Y-Z view", functools.partial(draw_lambda, elev=0, azim=0)),
+            ("Go to X-Z view", functools.partial(draw_lambda, elev=0, azim=-90))
+        ]
 
     def set_message(self, s):
         """Display a message on toolbar or in status bar."""
@@ -3364,6 +3375,9 @@ class NavigationToolbar2:
             Returns `NavigationToolbar2.UNKNOWN_SAVED_STATUS` when
             the backend does not provide the information.
         """
+        raise NotImplementedError
+
+    def snap_view(self, *args):
         raise NotImplementedError
 
     def update(self):

--- a/lib/matplotlib/backends/backend_qt.py
+++ b/lib/matplotlib/backends/backend_qt.py
@@ -968,6 +968,14 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
                     QtWidgets.QMessageBox.StandardButton.NoButton)
         return fname
 
+    def snap_view(self, *args):
+        action = self._actions.get('snap_view')
+        btn = self.widgetForAction(action)
+        menu = QtWidgets.QMenu()
+        for label, action in self.options:
+            menu.addAction(label, action)
+        menu.exec(btn.mapToGlobal(QtCore.QPoint(0, btn.height())))
+
     def set_history_buttons(self):
         can_backward = self._nav_stack._pos > 0
         can_forward = self._nav_stack._pos < len(self._nav_stack) - 1


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
